### PR TITLE
proto: remove `(uint32_t)-1`

### DIFF
--- a/proto/rootlesscontainers.proto
+++ b/proto/rootlesscontainers.proto
@@ -25,7 +25,8 @@ package rootlesscontainers;
 message Resource {
    // Zero-value MUST be parsed as a literally zero-value, not "unset".
    // To keep both uid and gid unchaged, the entire xattr value SHOULD be removed.
-   // To keep either one of uid or gid unchaged, -1 value SHOULD be set.
+   // To keep either one of uid or gid unchaged, 0xFFFFFFFF (in other words,
+   // `(uint32_t) -1`, see also chown(2)) value SHOULD be set.
    // (Because some protobuf bindings cannot distinguish "unset" from zero-value.)
    uint32 uid = 1;
    uint32 gid = 2;


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>